### PR TITLE
Core/Commands: Implemented .npc reload [all] command

### DIFF
--- a/sql/ashamane/auth/2018_05_19_00_auth.sql
+++ b/sql/ashamane/auth/2018_05_19_00_auth.sql
@@ -1,0 +1,7 @@
+DELETE FROM `rbac_permissions` WHERE id IN (2006);
+INSERT INTO `rbac_permissions` VALUES
+(2006, "Command: npc reload");
+
+DELETE FROM `rbac_linked_permissions` WHERE id = 192 AND linkedid IN (2006);
+INSERT INTO `rbac_linked_permissions` VALUES
+(192, 2006);

--- a/sql/ashamane/world/2018_05_19_00_world.sql
+++ b/sql/ashamane/world/2018_05_19_00_world.sql
@@ -1,0 +1,8 @@
+DELETE FROM `trinity_string` WHERE `entry` IN (5073, 5074);
+INSERT INTO `trinity_string` (`entry`, `content_default`) VALUES 
+(5073, 'Selected creature reloaded.'),
+(5074, 'Selected creature and all same entries in vision range reloaded.');
+
+DELETE FROM `command` WHERE `name`='npc reload';
+INSERT INTO `command` (`name`, `permission`, `help`) VALUES
+('npc reload', 2006, 'Syntax: .npc reload [all]\n\nReloads selected creature or all same creatures in vision range if #all argument is provided\nRespawns creature, reloads it\'s template, addon, aura, ai/script, etc data\nNote: it does not reload smart_scripts table');

--- a/src/server/game/Accounts/RBAC.h
+++ b/src/server/game/Accounts/RBAC.h
@@ -788,6 +788,7 @@ enum RBACPermissions
     RBAC_PERM_COMMAND_LIST_QUESTS                            = 2003,
     RBAC_PERM_COMMAND_BLACKMARKET                            = 2004,
     RBAC_PERM_COMMAND_BLACKMARKET_SET_DURATION               = 2005,
+    RBAC_PERM_COMMAND_NPC_RELOAD                             = 2006,
     RBAC_PERM_MAX
 };
 

--- a/src/server/game/Entities/Creature/Creature.h
+++ b/src/server/game/Entities/Creature/Creature.h
@@ -88,6 +88,8 @@ class TC_GAME_API Creature : public Unit, public GridObject<Creature>, public Ma
         void LoadEquipment(int8 id = 1, bool force = false);
         void SetSpawnHealth();
 
+		void ReLoad(bool skipDB);
+
         ObjectGuid::LowType GetSpawnId() const { return m_spawnId; }
 
         void Update(uint32 time) override;                         // overwrited Unit::Update

--- a/src/server/game/Globals/ObjectMgr.cpp
+++ b/src/server/game/Globals/ObjectMgr.cpp
@@ -527,6 +527,8 @@ void ObjectMgr::LoadCreatureTemplateAddons()
 {
     uint32 oldMSTime = getMSTime();
 
+	_creatureTemplateAddonStore.clear(); // needed for reload
+
     //                                                 0       1       2      3       4       5        6             7              8          9
     QueryResult result = WorldDatabase.Query("SELECT entry, path_id, mount, bytes1, bytes2, emote, aiAnimKit, movementAnimKit, meleeAnimKit, auras FROM creature_template_addon");
 
@@ -1143,6 +1145,8 @@ void ObjectMgr::CheckCreatureTemplate(CreatureTemplate const* cInfo)
 void ObjectMgr::LoadCreatureAddons()
 {
     uint32 oldMSTime = getMSTime();
+
+	_creatureAddonStore.clear(); // needed for reload
 
     //                                                0       1       2      3       4       5        6             7              8          9
     QueryResult result = WorldDatabase.Query("SELECT guid, path_id, mount, bytes1, bytes2, emote, aiAnimKit, movementAnimKit, meleeAnimKit, auras FROM creature_addon");

--- a/src/server/game/Miscellaneous/Language.h
+++ b/src/server/game/Miscellaneous/Language.h
@@ -1045,6 +1045,8 @@ enum TrinityStrings
     LANG_NPCINFO_UNIT_FIELD_FLAGS_2     = 5070,
     LANG_NPCINFO_UNIT_FIELD_FLAGS_3     = 5071,
     LANG_NPCINFO_NPC_FLAGS              = 5072,
+    LANG_NPC_RELOADED                   = 5073,
+    LANG_NPCS_RELOADED                  = 5074,
 
     // Room for more Trinity strings      5073-9999
 

--- a/src/server/scripts/Commands/cs_npc.cpp
+++ b/src/server/scripts/Commands/cs_npc.cpp
@@ -264,7 +264,7 @@ public:
             { "follow",    rbac::RBAC_PERM_COMMAND_NPC_FOLLOW,    false, nullptr,           "", npcFollowCommandTable },
             { "set",       rbac::RBAC_PERM_COMMAND_NPC_SET,       false, nullptr,              "", npcSetCommandTable },
             { "evade",     rbac::RBAC_PERM_COMMAND_NPC_EVADE,     false, &HandleNpcEvadeCommand,             ""       },
-			{ "reload",    rbac::RBAC_PERM_COMMAND_NPC_RELOAD,    false, &HandleNpcReloadCommand,            ""		  },
+            { "reload",    rbac::RBAC_PERM_COMMAND_NPC_RELOAD,    false, &HandleNpcReloadCommand,            ""		  },
         };
         static std::vector<ChatCommand> commandTable =
         {
@@ -1534,43 +1534,35 @@ public:
         return true;
     }
 
-	static bool HandleNpcReloadCommand(ChatHandler* handler, char const* args)
-	{
-		Creature* creatureTarget = handler->getSelectedCreature();
-		if (!creatureTarget || creatureTarget->IsPet() || creatureTarget->IsGuardian())
-		{
-			handler->PSendSysMessage(LANG_SELECT_CREATURE);
-			handler->SetSentErrorMessage(true);
-			return false;
-		}
+    static bool HandleNpcReloadCommand(ChatHandler* handler, char const* args)
+    {
+        Creature* creatureTarget = handler->getSelectedCreature();
+        if (!creatureTarget || creatureTarget->IsPet() || creatureTarget->IsGuardian())
+        {
+            handler->PSendSysMessage(LANG_SELECT_CREATURE);
+            handler->SetSentErrorMessage(true);
+            return false;
+        }
 
-		creatureTarget->ReLoad(false);
+        creatureTarget->ReLoad(false);
 
-		char* all_str = args ? strtok((char*)args, " ") : nullptr;
+        if (args && args == "all")
+        {
+            Player* me = handler->GetSession()->GetPlayer();
+            std::list<Creature*> list;
+            me->GetCreatureListWithEntryInGrid(list, creatureTarget->GetEntry(), me->GetMap()->GetVisibilityRange());
 
-		if (all_str && stricmp(all_str, "all") == 0)
-		{
-			Player* me = handler->GetSession()->GetPlayer();
-			std::list<Creature*> list;
-			me->GetCreatureListWithEntryInGrid(list, creatureTarget->GetEntry(), me->GetMap()->GetVisibilityRange());
+            for (Creature* creature : list)
+                if (creature != creatureTarget)
+                    creature->ReLoad(true);
 
-			if (!list.empty())
-			{
-				for (std::list<Creature*>::iterator itr = list.begin(); itr != list.end(); ++itr)
-				{
-					Creature* c = (*itr);
-					if (!c || c == creatureTarget)
-						continue;
-					c->ReLoad(true);
-				}
-			}
-			handler->PSendSysMessage(LANG_NPCS_RELOADED);
-		}
-		else
-			handler->PSendSysMessage(LANG_NPC_RELOADED);
+            handler->PSendSysMessage(LANG_NPCS_RELOADED);
+        }
+        else
+            handler->PSendSysMessage(LANG_NPC_RELOADED);
 
-		return true;
-	}
+        return true;
+    }
 
     static bool HandleNpcAddFormationCommand(ChatHandler* handler, char const* args)
     {

--- a/src/server/scripts/Commands/cs_npc.cpp
+++ b/src/server/scripts/Commands/cs_npc.cpp
@@ -1546,7 +1546,7 @@ public:
 
         creatureTarget->ReLoad(false);
 
-        if (args && stricmp(args, "all"))
+        if (args && stricmp(args, "all") == 0)
         {
             Player* me = handler->GetSession()->GetPlayer();
             std::list<Creature*> list;

--- a/src/server/scripts/Commands/cs_npc.cpp
+++ b/src/server/scripts/Commands/cs_npc.cpp
@@ -1546,7 +1546,7 @@ public:
 
         creatureTarget->ReLoad(false);
 
-        if (args && args == "all")
+        if (args && stricmp(args, "all"))
         {
             Player* me = handler->GetSession()->GetPlayer();
             std::list<Creature*> list;


### PR DESCRIPTION
Reloads selected creature or all same creatures in vision range if #all argument is provided
Resets, respawns creature, reloads it's template, addons, auras, ai/script, etc

Note: it does not reload smart_scripts table

<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Adds the possibility to reload any creature spawn ingame

**Issues addressed:** Closes #  (insert issue tracker number)


**Tests performed:** (Does it build, tested in-game, etc.)
Built, tested in-game

**Known issues and TODO list:** (add/remove lines as needed)

- [should be fine] 


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
