### PR TITLE
Core/Commands: Added "only" arg for Reset Talents command, it will on…

### DIFF
--- a/src/server/game/Chat/Chat.h
+++ b/src/server/game/Chat/Chat.h
@@ -186,7 +186,7 @@ public:
     };
 
     CommandArgs(ChatHandler* handler, char const* args) : _validArgs(false), _handler(handler), _charArgs(args) { }
-    CommandArgs(ChatHandler* handler, char const* args, std::initializer_list<CommandArgsType> argsType) : _validArgs(false), _handler(handler), _charArgs(args)
+    CommandArgs(ChatHandler* handler, char const* args, std::initializer_list<CommandArgsType> argsType) : _validArgs(false), _handler(handler), _charArgs(args), _pos(0)
     {
         Initialize(argsType);
     }
@@ -194,10 +194,15 @@ public:
     bool ValidArgs() const { return _validArgs; }
     void Initialize(std::initializer_list<CommandArgsType> argsType);
 
-    uint32 GetArgInt(uint32 index)          { return GetArg<int32>(index); }
+    int32 GetArgInt(uint32 index)          { return GetArg<int32>(index); }
     uint32 GetArgUInt(uint32 index)         { return GetArg<uint32>(index); }
     float GetArgFloat(uint32 index)         { return GetArg<float>(index); }
     std::string GetArgString(uint32 index)  { return GetArg<std::string>(index); }
+
+    uint32 Count() { return _args.size(); }
+
+    template<typename T>
+    T GetNextArg() { return boost::any_cast<T>(_args[_pos++]); }
 
     template<typename T>
     T GetArg(uint32 index)
@@ -212,6 +217,7 @@ private:
     char const* _charArgs;
     std::initializer_list<CommandArgsType> _argsType;
     std::vector<boost::any> _args;
+    int32 _pos;
 };
 
 #endif


### PR DESCRIPTION
Core/Commands: Added "only" arg for Reset Talents command, it will only reset talents without resetting specialization too

Some work on CommandArgs helper class

<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Added "only" argument to .reset talents <only> <playername>

**Issues addressed:** Closes #  (insert issue tracker number)
it was annoying that it always full reseted my spec to default
example, working on fire mage spells, want to reset talents and it jumped back to frost cuz that is the default ...

**Tests performed:** (Does it build, tested in-game, etc.)
works as intended, usage:
.reset talents
.reset talents playername
.reset talents only
.reset talents only playername

works from console too, as before
note: offline players still get a full reset at relog

**Known issues and TODO list:** (add/remove lines as needed)

- [ ] 
- [ ] 


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
