### PR TITLE
DB/World Fix allied races display after polymorph

### DIFF
--- a/sql/ashamane/world/2018_07_14_05_world_creature_model_info.sql
+++ b/sql/ashamane/world/2018_07_14_05_world_creature_model_info.sql
@@ -1,0 +1,10 @@
+DELETE FROM `creature_model_info` WHERE `DisplayID` IN (75078, 75079, 75080, 75081, 75082, 75083, 75084, 75085);
+INSERT INTO `creature_model_info` (`DisplayID`, `BoundingRadius`, `CombatReach`, `DisplayID_Other_Gender`, `VerifiedBuild`) VALUES
+(75078, 0.306, 1.5, 0, 0),
+(75079, 0.306, 1.5, 0, 0),
+(75080, 0.306, 1.5, 0, 0),
+(75081, 0.306, 1.5, 0, 0),
+(75082, 0.306, 1.5, 0, 0),
+(75083, 0.306, 1.5, 0, 0),
+(75084, 0.306, 1.5, 0, 0),
+(75085, 0.306, 1.5, 0, 0);


### PR DESCRIPTION
**Changes proposed:**

-  Add data in creature_model_info for allied races

**Issues addressed:** Closes #  (insert issue tracker number)

- mantis 402

**Tests performed:** (Does it build, tested in-game, etc.)

- For each allied race/gender combination, have a npc cast polymorph on me (spell 118) then .unaura 118 and checking that the model is not broken

**Known issues and TODO list:** (add/remove lines as needed)

- Note : values for BoundingRadius and CombatReach were only sniffed for Nightborne but they seem to be the same for every player race anyway
