### PR TITLE
Scripts/DK Fix a crash when controlling the Eye of Acherus

### DIFF
--- a/src/server/scripts/EasternKingdoms/ScarletEnclave/chapter1.cpp
+++ b/src/server/scripts/EasternKingdoms/ScarletEnclave/chapter1.cpp
@@ -373,7 +373,7 @@ class npc_eye_of_acherus : public CreatureScript
                 me->SetDisplayId(me->GetCreatureTemplate()->Modelid1);
                 if (Player* owner = me->GetCharmerOrOwner()->ToPlayer())
                 {
-                    me->GetCharmInfo()->InitPossessCreateSpells();
+                    me->InitCharmInfo()->InitPossessCreateSpells();
                     owner->SendAutoRepeatCancel(me);
                 }
 


### PR DESCRIPTION
**Issues addressed:** Closes #  (insert issue tracker number)

mantis 306

**Tests performed:** (Does it build, tested in-game, etc.)

- Taking control of the Eye of Acherus, core doesn't crash anymore
