### PR TITLE
DB/World Clean up Quest 26290 and fix vendor

### DIFF
--- a/sql/ashamane/world/2018_07_21_99_secrets_tower_fix.sql
+++ b/sql/ashamane/world/2018_07_21_99_secrets_tower_fix.sql
@@ -1,0 +1,39 @@
+SET @NPC_HELIX_LUMBERING_OAF        := 42654;
+SET @NPC_HELIX_GEARBREAKER          := 42655;
+SET @NPC_SHADOWY_FIGURE             := 42662;
+SET @NPC_UNUSED_TUNNELER_VISUAL     := 17234;
+SET @NPC_QUARTERMASTER_LEWIS        :=   491;
+
+-- problems:
+-- the npc used to trigger the event is summoned by the event, thus retriggering and resummoning
+-- It looks visually terrible, while still completing the quest, with double spawns and double text
+-- the npcs are already spawned, and are spawned again by the script
+-- solution, find an unused invisible dummy, spawn that and attach script to the dummy
+-- remove unwanted permanent spawns
+
+UPDATE `creature_template` SET `ScriptName` = '' WHERE `entry` = @NPC_SHADOWY_FIGURE;
+UPDATE `creature_template` SET `ScriptName` = 'npc_shadowy_tower' WHERE `entry` = @NPC_UNUSED_TUNNELER_VISUAL;
+	
+-- remove lumbering oaf and gearbreaker spawns
+DELETE FROM `creature`
+WHERE `id` in (@NPC_HELIX_LUMBERING_OAF,@NPC_HELIX_GEARBREAKER);
+
+-- update our shadowy figure to be the invisible dummy
+UPDATE `creature`
+SET `id` = @NPC_UNUSED_TUNNELER_VISUAL,
+`modelid` = 0,
+spawndist = 0,
+MovementType = 0
+WHERE `id` = @NPC_SHADOWY_FIGURE;
+
+-- fix up vendor quartermaster lewis
+UPDATE `creature_template`
+SET `family` = 0,
+`type` = 7
+WHERE `entry` = @NPC_QUARTERMASTER_LEWIS;
+
+UPDATE `gossip_menu_option`
+SET `OptionType` = 3,
+`OptionNpcFlag` = 128
+WHERE `MenuId` = 4107
+AND `OptionIndex` = 0;


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**
Fix up Quest 26290, and fix Quartermaster Lewis vendor

**Issues addressed:** Closes #  (insert issue tracker number)
The npc used to trigger the event is summoned by the event, thus retriggering and resummoning
It looks visually terrible, while still completing the quest, with double spawns and double text
The npcs are already spawned, and are spawned again by the script
Quartermaster Lewis does not want to show his goods

**Tests performed:** (Does it build, tested in-game, etc.)
Compiled and tested

**Known issues and TODO list:** (add/remove lines as needed)

- [ ] 
- [ ] 


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
