### PR TITLE
DB/World Fix Quest 26352->26355

### DIFF
--- a/sql/ashamane/world/2018_07_21_99_quest_26352_fix.sql
+++ b/sql/ashamane/world/2018_07_21_99_quest_26352_fix.sql
@@ -1,0 +1,44 @@
+UPDATE `creature_loot_template`
+SET `Chance` = 15
+WHERE (`Entry` = 515 AND `Item` = 1357);
+
+UPDATE `creature_loot_template`
+SET `Chance` = 15
+WHERE (`Entry` = 126 AND `Item` = 1357);
+
+UPDATE `creature_loot_template`
+SET `Chance` = 11
+WHERE (`Entry` = 456 AND `Item` = 1357);
+
+UPDATE `creature_loot_template`
+SET `Chance` = 4
+WHERE (`Entry` = 127 AND `Item` = 1357);
+
+UPDATE `creature_loot_template`
+SET `Chance` = 4
+WHERE (`Entry` = 391 AND `Item` = 1357);
+
+
+-- fix up quest markers
+DELETE FROM quest_poi
+WHERE QuestID IN (26354,26355,26356);
+
+DELETE FROM quest_poi_points
+WHERE QuestID IN (26354,26355,26356);
+
+INSERT INTO `quest_poi_points` (`QuestID`, `Idx1`, `Idx2`, `X`, `Y`, `VerifiedBuild`) VALUES
+(26354, 1, 0, -10514, 2110, 25881), -- Captain Sanders' Hidden Treasure
+(26354, 0, 0, -10515, 1599, 25881), -- Captain Sanders' Hidden Treasure
+(26355, 1, 0, -10515, 1599, 25881), -- Captain Sanders' Hidden Treasure
+(26355, 0, 0, -9797, 1595, 25881), -- Captain Sanders' Hidden Treasure
+(26356, 1, 0, -9797, 1595, 25881), -- Captain Sanders' Hidden Treasure
+(26356, 0, 0, -9794, 2108, 25881); -- Captain Sanders' Hidden Treasure
+
+
+INSERT INTO `quest_poi` (`QuestID`, `BlobIndex`, `Idx1`, `ObjectiveIndex`, `QuestObjectiveID`, `QuestObjectID`, `MapID`, `WorldMapAreaId`, `Floor`, `Priority`, `Flags`, `WorldEffectID`, `PlayerConditionID`, `WoDUnk1`, `AlwaysAllowMergingBlobs`, `VerifiedBuild`) VALUES
+(26354, 0, 1, 32, 0, 0, 0, 39, 0, 0, 0, 0, 0, 0, 0, 25881), -- Captain Sanders' Hidden Treasure
+(26354, 0, 0, -1, 0, 0, 0, 39, 0, 0, 1, 0, 0, 0, 0, 25881), -- Captain Sanders' Hidden Treasure
+(26355, 0, 1, 32, 0, 0, 0, 39, 0, 0, 0, 0, 0, 0, 0, 25881), -- Captain Sanders' Hidden Treasure
+(26355, 0, 0, -1, 0, 0, 0, 39, 0, 0, 1, 0, 0, 0, 0, 25881), -- Captain Sanders' Hidden Treasure
+(26356, 0, 1, 32, 0, 0, 0, 39, 0, 0, 0, 0, 0, 0, 0, 25881), -- Captain Sanders' Hidden Treasure
+(26356, 0, 0, -1, 0, 0, 0, 39, 0, 0, 1, 0, 0, 0, 0, 25881); -- Captain Sanders' Hidden Treasure


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**
Change drop rates so Treasure map can drop before you win lotto

**Issues addressed:** Closes #  (insert issue tracker number)
1. Drop rates on Treasure map are wrong (way too low)
2. Quest markers are broken for all stages

**Tests performed:** (Does it build, tested in-game, etc.)
Compiled, Tested

**Known issues and TODO list:** (add/remove lines as needed)

- [ ] 
- [ ] 


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
