### PR TITLE
Spells/Druid Fix Savage Roar duration.

### DIFF
--- a/src/server/scripts/Spells/spell_druid.cpp
+++ b/src/server/scripts/Spells/spell_druid.cpp
@@ -764,7 +764,7 @@ public:
             if (!caster)
                 return;
 
-            int32 bonusDuration = m_ComboPoint * 8 * IN_MILLISECONDS;
+            int32 bonusDuration = m_ComboPoint * 6 * IN_MILLISECONDS;
             int32 maxDuration = GetSpellInfo()->GetMaxDuration();
             int32 newDuration = m_OldDuration + GetSpellInfo()->GetDuration() + bonusDuration;
 


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

This patch fix the duration of Savage Roar per combo points that was longer than in spell description.

**Issues addressed:**

None

**Tests performed:**

Build on Kubuntu 18.04 and tested in-game

**Known issues and TODO list:**

None

<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
