### PR TITLE
Spells/Druid Fix Swipe and Brutal Slash not awards Combo Point.

### DIFF
--- a/sql/ashamane/world/2018_08_15_01_world_spell_druid.sql
+++ b/sql/ashamane/world/2018_08_15_01_world_spell_druid.sql
@@ -1,0 +1,4 @@
+DELETE FROM `spell_script_names` WHERE `spell_id` IN (106785, 202028);
+INSERT INTO `spell_script_names` VALUE
+(106785, "spell_dru_swipe"),
+(202028, "spell_dru_brutal_slash");

--- a/sql/ashamane/world/2018_08_15_01_world_spell_swipe.sql
+++ b/sql/ashamane/world/2018_08_15_01_world_spell_swipe.sql
@@ -1,3 +1,0 @@
-DELETE FROM `spell_script_names` WHERE `spell_id` IN (106785);
-INSERT INTO `spell_script_names` VALUE
-(106785, "spell_dru_swipe");

--- a/sql/ashamane/world/2018_08_15_01_world_spell_swipe.sql
+++ b/sql/ashamane/world/2018_08_15_01_world_spell_swipe.sql
@@ -1,0 +1,3 @@
+DELETE FROM `spell_script_names` WHERE `spell_id` IN (106785);
+INSERT INTO `spell_script_names` VALUE
+(106785, "spell_dru_swipe");

--- a/src/server/scripts/Spells/spell_druid.cpp
+++ b/src/server/scripts/Spells/spell_druid.cpp
@@ -2345,6 +2345,35 @@ private:
     bool m_awardComboPoint = true;
 };
 
+// Brutal Slash - 202028
+class spell_dru_brutal_slash : public SpellScript
+{
+    PrepareSpellScript(spell_dru_brutal_slash);
+
+    void HandleOnHit(SpellEffIndex /*effIndex*/)
+    {
+        Unit* caster = GetCaster();
+        Unit* target = GetHitUnit();
+        if (!caster || !target)
+            return;
+
+        // This prevent awarding multiple Combo Points when multiple targets hit with Brutal Slash AoE
+        if(m_awardComboPoint)
+            // Awards the caster 1 Combo Point (get value from the spell data)
+            caster->ModifyPower(POWER_COMBO_POINTS, sSpellMgr->GetSpellInfo(SPELL_DRUID_SWIPE_CAT)->GetEffect(EFFECT_0)->BasePoints);
+
+        m_awardComboPoint = false;
+    }
+
+    void Register() override
+    {
+        OnEffectHitTarget += SpellEffectFn(spell_dru_brutal_slash::HandleOnHit, EFFECT_0, SPELL_EFFECT_DUMMY);
+    }
+
+private:
+    bool m_awardComboPoint = true;
+};
+
 void AddSC_druid_spell_scripts()
 {
     // Spells Scripts
@@ -2388,6 +2417,7 @@ void AddSC_druid_spell_scripts()
     new spell_dru_travel_form();
     RegisterAuraScript(aura_dru_charm_woodland_creature);
     RegisterSpellScript(spell_dru_swipe);
+    RegisterSpellScript(spell_dru_brutal_slash);
 
     RegisterSpellScript(spell_dru_thrash);
     RegisterAuraScript(spell_dru_thrash_periodic_damage);

--- a/src/server/scripts/Spells/spell_druid.cpp
+++ b/src/server/scripts/Spells/spell_druid.cpp
@@ -2307,6 +2307,44 @@ class aura_dru_charm_woodland_creature : public AuraScript
     }
 };
 
+// Swipe - 106785
+class spell_dru_swipe : public SpellScript
+{
+    PrepareSpellScript(spell_dru_swipe);
+
+    void HandleOnHit(SpellEffIndex /*effIndex*/)
+    {
+        Unit* caster = GetCaster();
+        Unit* target = GetHitUnit();
+        if (!caster || !target)
+            return;
+
+        int32 damage = GetHitDamage();
+        int32 casterLevel = caster->GetLevelForTarget(caster);
+
+        // This prevent awarding multiple Combo Points when multiple targets hit with Swipe AoE
+        if(m_awardComboPoint)
+            // Awards the caster 1 Combo Point (get value from the spell data)
+            caster->ModifyPower(POWER_COMBO_POINTS, sSpellMgr->GetSpellInfo(SPELL_DRUID_SWIPE_CAT)->GetEffect(EFFECT_0)->BasePoints);
+
+        // If caster is level >= 44 and the target is bleeding, deals 20% increased damage (get value from the spell data)
+        if ((casterLevel >= 44) && target->HasAuraState(AURA_STATE_BLEEDING))
+            AddPct(damage, sSpellMgr->GetSpellInfo(SPELL_DRUID_SWIPE_CAT)->GetEffect(EFFECT_1)->BasePoints);
+
+        SetHitDamage(damage);
+
+        m_awardComboPoint = false;
+    }
+
+    void Register() override
+    {
+        OnEffectHitTarget += SpellEffectFn(spell_dru_swipe::HandleOnHit, EFFECT_1, SPELL_EFFECT_DUMMY);
+    }
+
+private:
+    bool m_awardComboPoint = true;
+};
+
 void AddSC_druid_spell_scripts()
 {
     // Spells Scripts
@@ -2349,6 +2387,7 @@ void AddSC_druid_spell_scripts()
     new spell_dru_travel_form_dummy();
     new spell_dru_travel_form();
     RegisterAuraScript(aura_dru_charm_woodland_creature);
+    RegisterSpellScript(spell_dru_swipe);
 
     RegisterSpellScript(spell_dru_thrash);
     RegisterAuraScript(spell_dru_thrash_periodic_damage);


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**
- Add script for Swipe (https://www.wowhead.com/spell=106785) and Brutal Slash (https://www.wowhead.com/spell=202028).
- Fix Swipe and Brutal Slash not awards Combo Point.
- Fix Swipe not deal 20% increased damage on bleeding target.

**Issues addressed:**

None

**Tests performed:**

Build on Kubuntu 18.04 and tested in-game.

**Known issues and TODO list:**

None

<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
