### PR TITLE
Spells/Druid Fix Shred damage

### DIFF
--- a/sql/ashamane/world/2018_08_20_01_world_spell_shred.sql
+++ b/sql/ashamane/world/2018_08_20_01_world_spell_shred.sql
@@ -1,0 +1,3 @@
+DELETE FROM `spell_script_names` WHERE `spell_id` = '5221';
+INSERT INTO `spell_script_names` VALUE
+(5221, "spell_dru_shred");

--- a/src/server/scripts/Spells/spell_druid.cpp
+++ b/src/server/scripts/Spells/spell_druid.cpp
@@ -2426,7 +2426,7 @@ class spell_dru_shred : public SpellScript
         int32 damage = GetHitDamage();
         int32 casterLevel = caster->GetLevelForTarget(caster);
 
-        // If caster is level >= 56, While stealthed or have Incarnation: King of the Jungle active,
+        // If caster is level >= 56, While stealthed or have Incarnation: King of the Jungle aura,
         // deals 50% increased damage (get value from the spell data), and has double the chance to critically strike
         // FIXME: Find a way to temporary modify critical strike change
         if ((casterLevel >= 56) && (m_stealthed || caster->HasAura(SPELL_DRUID_INCARNATION_KING_OF_JUNGLE)))

--- a/src/server/scripts/Spells/spell_druid.cpp
+++ b/src/server/scripts/Spells/spell_druid.cpp
@@ -2434,9 +2434,7 @@ class spell_dru_shred : public SpellScript
         // deals 50% increased damage (get value from the spell data), and has double the chance to critically strike
         // FIXME: Find a way to temporary modify critical strike change
         if ((casterLevel >= 56) && (m_stealthed || caster->HasAura(SPELL_DRUID_INCARNATION_KING_OF_JUNGLE)))
-        {
             AddPct(damage, sSpellMgr->GetSpellInfo(SPELL_DRUID_SHRED)->GetEffect(EFFECT_3)->BasePoints);
-        }
 
         SetHitDamage(damage);
     }

--- a/src/server/scripts/Spells/spell_druid.cpp
+++ b/src/server/scripts/Spells/spell_druid.cpp
@@ -2426,15 +2426,15 @@ class spell_dru_shred : public SpellScript
         int32 damage = GetHitDamage();
         int32 casterLevel = caster->GetLevelForTarget(caster);
 
-        // If caster is level >= 44 and the target is bleeding, deals 20% increased damage (get value from the spell data)
-        if ((casterLevel >= 44) && target->HasAuraState(AURA_STATE_BLEEDING))
-            AddPct(damage, sSpellMgr->GetSpellInfo(SPELL_DRUID_SHRED)->GetEffect(EFFECT_4)->BasePoints);
-
         // If caster is level >= 56, While stealthed or have Incarnation: King of the Jungle active,
         // deals 50% increased damage (get value from the spell data), and has double the chance to critically strike
         // FIXME: Find a way to temporary modify critical strike change
         if ((casterLevel >= 56) && (m_stealthed || caster->HasAura(SPELL_DRUID_INCARNATION_KING_OF_JUNGLE)))
             AddPct(damage, sSpellMgr->GetSpellInfo(SPELL_DRUID_SHRED)->GetEffect(EFFECT_3)->BasePoints);
+
+        // If caster is level >= 44 and the target is bleeding, deals 20% increased damage (get value from the spell data)
+        if ((casterLevel >= 44) && target->HasAuraState(AURA_STATE_BLEEDING))
+            AddPct(damage, sSpellMgr->GetSpellInfo(SPELL_DRUID_SHRED)->GetEffect(EFFECT_4)->BasePoints);
 
         SetHitDamage(damage);
     }

--- a/src/server/scripts/Spells/spell_druid.cpp
+++ b/src/server/scripts/Spells/spell_druid.cpp
@@ -2424,8 +2424,6 @@ class spell_dru_shred : public SpellScript
 
     void HandleCritChance(Unit* /*victim*/, float& chance)
     {
-        Unit* caster = GetCaster();
-
         // If caster is level >= 56, While stealthed or have Incarnation: King of the Jungle aura,
         // Double the chance to critically strike
         if ((m_casterLevel >= 56) && (m_stealthed || m_incarnation))


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**
- Add script to Shred (https://www.wowhead.com/spell=5221).
- Fix Shred not deal extra damage against bleeding target.
- Fix Shred not deal extra damage when the caster is stealthed.

**Issues addressed:**

None

**Tests performed:**

Build on Kubuntu 18.04, tested in game.

**Known issues and TODO list:**

- I'm not sure if my implementation of extra damage calculation was correct, do it calculate the way I implement it or it add the percentage (20% + 50% = 70%), then calculate the extra damage?
- Double critical strike change while stealthed did not work, as I did not know the way to temporary modify critical strike change in script.
If anyone know, please lets me know in the comment.

<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
