### PR TITLE
DB/World Fix Dolanaar Cooking Trainer

### DIFF
--- a/sql/ashamane/world/2018_10_14_01_world_trainer.sql
+++ b/sql/ashamane/world/2018_10_14_01_world_trainer.sql
@@ -1,0 +1,1 @@
+UPDATE creature_template SET gossip_menu_id = '0' WHERE entry = '6286';


### PR DESCRIPTION
Fix NPC 6286 which is a cooking trainer in Dolanaar, wrong menu_gossip ID

<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  
-  
-  

**Issues addressed:** Closes #  (insert issue tracker number)


**Tests performed:** (Does it build, tested in-game, etc.)


**Known issues and TODO list:** (add/remove lines as needed)

- [ ] 
- [ ] 


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
