### PR TITLE
DB/World Quest "Filling up the spellbook"

### DIFF
--- a/sql/ashamane/world/2018_10_14_03_world_quest.sql
+++ b/sql/ashamane/world/2018_10_14_03_world_quest.sql
@@ -1,0 +1,1 @@
+DELETE FROM quest_template WHERE ID = '24526'; 


### PR DESCRIPTION
This quest should be removed because of the revamp of spells trainers, this quest was added in 4.0.3 when you could buy spells instead of having them already learned.

<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  
-  
-  

**Issues addressed:** Closes #  (insert issue tracker number)


**Tests performed:** (Does it build, tested in-game, etc.)


**Known issues and TODO list:** (add/remove lines as needed)

- [ ] 
- [ ] 


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
