### PR TITLE
Howling Blast applies Frost Fever to all targets

### DIFF
--- a/src/server/scripts/Spells/spell_dk.cpp
+++ b/src/server/scripts/Spells/spell_dk.cpp
@@ -1232,8 +1232,16 @@ class spell_dk_howling_blast_aoe : public SpellScript
     void HandleOnHit(SpellEffIndex /*effIndex*/)
     {
         if (Unit* target = GetHitUnit())
-            if (target->GetGUID() == tar)
-                PreventHitDamage();
+        {
+			if (target->GetGUID() == tar)
+				PreventHitDamage();
+			else
+			{
+				Unit* caster = GetCaster();
+				if (caster)
+					caster->CastSpell(target, SPELL_DK_FROST_FEVER, true);
+			}
+        }
     }
 
     void Register() override


### PR DESCRIPTION
Howling Blast was only applying Frost Fever to the primary target.  It now applies it to all targets.

<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**
Howling Blast now applies Frost Fever to secondary targets.

**Issues addressed:** Closes #  (insert issue tracker number)
Howling Blast wasn't correctly applying Frost Fever to secondary targets

**Tests performed:** (Does it build, tested in-game, etc.)
Builds fine, was tested in-game.

**Known issues and TODO list:** (add/remove lines as needed)
None