### PR TITLE
Core/Pet: Fix crash

### DIFF
--- a/src/server/game/Entities/Pet/Pet.cpp
+++ b/src/server/game/Entities/Pet/Pet.cpp
@@ -414,8 +414,9 @@ void Pet::SavePetToDB(PetSaveMode mode)
         stmt->setInt16(7, m_petSlot);
         stmt->setString(8, m_name);
         stmt->setUInt8(9, HasPetFlag(UNIT_PET_FLAG_CAN_BE_RENAMED) ? 0 : 1);
-        stmt->setUInt32(10, curhealth);
-        stmt->setUInt32(11, curmana);
+        stmt->setUInt8(10, IsActive() ? 1 : 0);
+        stmt->setUInt32(11, curhealth);
+        stmt->setUInt32(12, curmana);
 
         stmt->setString(13, GenerateActionBarData());
 

--- a/src/server/game/Entities/Pet/Pet.cpp
+++ b/src/server/game/Entities/Pet/Pet.cpp
@@ -420,10 +420,10 @@ void Pet::SavePetToDB(PetSaveMode mode)
 
         stmt->setString(13, GenerateActionBarData());
 
-        stmt->setUInt32(13, time(NULL));
-        stmt->setUInt32(14, m_unitData->CreatedBySpell);
-        stmt->setUInt8(15, getPetType());
-        stmt->setUInt16(16, m_petSpecialization);
+        stmt->setUInt32(14, time(NULL));
+        stmt->setUInt32(15, m_unitData->CreatedBySpell);
+        stmt->setUInt8(16, getPetType());
+        stmt->setUInt16(17, m_petSpecialization);
         trans->Append(stmt);
 
         CharacterDatabase.CommitTransaction(trans);


### PR DESCRIPTION
Fix crash when save pet info to database

<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Fix parameters in query CHAR_INS_PET
-  
-  

**Issues addressed:** Closes #  (insert issue tracker number)


**Tests performed:** (Does it build, tested in-game, etc.)
Does it build and tested in-game when call a pet

**Known issues and TODO list:** (add/remove lines as needed)

- [ ] 
- [ ] 


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
